### PR TITLE
Make clone elem safer

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -782,7 +782,9 @@
 					}
 					else {
 						// Remove clone
-						cloneEl && cloneEl.parentNode.removeChild(cloneEl);
+						if (cloneEl && cloneEl.parentNode) {
+							cloneEl.parentNode.removeChild(cloneEl);
+						}
 
 						if (dragEl.nextSibling !== nextEl) {
 							// Get the index of the dragged element within its parent


### PR DESCRIPTION
Some times, with polymer-sortable,
cloneEl.parentNode.removeChild(cloneEl) sends the whole system
to irrecoverable error state
Checking cloneEl.parentNode it things safer